### PR TITLE
Propagate fix for AASd-014, bump meta and codegen

### DIFF
--- a/aas_core3_1_testgen/fixing.py
+++ b/aas_core3_1_testgen/fixing.py
@@ -316,9 +316,7 @@ class _Handyman(abstract_fixing.AbstractHandyman):
                         common.hash_path(path_hash, ["statements", i, "id_short"])
                     )
 
-        # Fix AASd-014: Either the attribute global asset ID or specific asset ID
-        # must be set if entity type is set to 'SelfManagedEntity'. They are not
-        # existing otherwise.
+        # Fix for AASd-014
         if that.entity_type is aas_types.EntityType.SELF_MANAGED_ENTITY:
             if that.global_asset_id is not None and that.specific_asset_ids is not None:
                 that.specific_asset_ids = None

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "icontract>=2.5.2,<3",
         "networkx==2.8",
         "typing-extensions==4.5.0",
-        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@e45fb6f#egg=aas-core-codegen",
+        "aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4afdc99#egg=aas-core-codegen",
     ],
     # fmt: off
     extras_require={
@@ -48,7 +48,7 @@ setup(
             "pydocstyle>=2.1.1<3",
             "coverage>=6,<7",
             "twine",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@77d3442#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5d409d6#egg=aas-core-meta",
             "hypothesis==6.46.3",
             "xmlschema==1.10.0",
             "jsonschema==4.17.3",


### PR DESCRIPTION
We propagate the fix for AASd-014, see #2.
We bump the meta and codegen versions to their latest.